### PR TITLE
use table from schema when populating CHANGES query

### DIFF
--- a/create.go
+++ b/create.go
@@ -118,7 +118,7 @@ func Create(db *gorm.DB) {
 				db.Statement.WriteQuoted(field.DBName)
 			}
 			db.Statement.WriteString(" FROM ")
-			db.Statement.WriteQuoted(db.Statement.Table)
+			db.Statement.WriteQuoted(sch.Table)
 			db.Statement.WriteString(" CHANGES(INFORMATION => APPEND_ONLY) BEFORE(statement=>LAST_QUERY_ID());")
 			rows, err := db.Statement.ConnPool.QueryContext(db.Statement.Context, db.Statement.SQL.String(), db.Statement.Vars...)
 			reflectIndex := 0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gorm-snowflake/gorm-snowflake
+module github.com/virtuslabs/gorm-snowflake
 
 go 1.23.0
 


### PR DESCRIPTION
 This should pick up any table name overrides. I ran into this issue when I combined the schema name with table name in my struct when implementing the TableName method.